### PR TITLE
Production deployment stack for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,24 @@ The frontend is configured with hot module replacement (HMR) for live updates du
 
 Changes to files in `frontend/src/` are automatically reflected in the browser.
 
+## Production
+
+The production stack runs the frontend, backend, and database together in Docker Compose.
+
+The frontend is built as a static Vue app and served by Nginx.
+The backend runs in production mode with `APP_ENV=production` and `APP_DEBUG=false`.
+
+Use the production compose file to build and run the full stack:
+```bash
+docker compose -f compose.prod.yaml up --build -d
+```
+
+The frontend bundle is baked with `http://localhost:${BACKEND_PORT}/api/v1` so it can talk to the backend without additional runtime configuration.
+
+Frontend: `http://localhost:${FRONTEND_PORT}`
+
+Backend: `http://localhost:${BACKEND_PORT}`
+
 ## Troubleshooting
 
 ### Backend Won't Start

--- a/README.md
+++ b/README.md
@@ -4,45 +4,53 @@
 
 CAA is a comprehensive events management platform that allows users to view all upcoming events from the hubs and clubs in the Northern of the Netherlands.
 
+> [!IMPORTANT]
+> This project is designed to run as a Docker Compose deployment — the frontend, backend, and database run as containers.
+> It is not intended to be deployed as a traditional single-server Laravel application (shared PHP hosting).
+> To run in production the target server must have `Docker` and `Docker Compose` installed; see the **Production** section for details.
+
 ## Technology Stack
 
-- **Backend**: Laravel 11 (PHP) with Passport OAuth
-- **Frontend**: Vue 3 with Vite bundler and Bootstrap Icons
-- **Database**: PostgreSQL 17
-- **Orchestration**: Docker Compose
-- **Admin Tool**: pgAdmin 4
-- **API Documentation**: Swagger/OpenAPI
+- **Backend**: Laravel 11 (PHP) with Passport OAuth for API authentication
+- **Frontend**: Vue 3 with Vite and Bootstrap Icons for the user interface
+- **Database**: PostgreSQL 17 for persistent application data
+- **Orchestration**: Docker Compose for local service management
+- **Admin Tool**: pgAdmin 4 for database administration
+- **API Documentation**: Swagger/OpenAPI for interactive endpoint docs
 
 ## Prerequisites
 
 - **Docker** and **Docker Compose** installed
 - **Git** for version control
-- Text editor or IDE
+- A text editor or IDE
 
 ## Project Structure
 
 ```
 caa/
-├── backend/                 # Laravel API application
-│   ├── app/                # Application logic
-│   ├── config/             # Configuration files
-│   ├── database/           # Migrations, factories, seeders
-│   ├── routes/             # API route definitions
-│   ├── tests/              # Test suites
-│   ├── storage/            # Application storage (logs, API docs)
-│   ├── .env.example        # Environment template
-│   └── Dockerfile
-├── frontend/               # Vue 3 application
-│   ├── src/               # Vue components and pages
-│   ├── public/            # Static assets
-│   ├── package.json
-│   └── Dockerfile
-├── database/              # Database configuration
-│   ├── sql/              # SQL files and stored procedures
-│   ├── pgadmin/          # pgAdmin configuration
-│   └── backups/          # Database backups
-├── docker-compose.yaml   # Service orchestration
-└── README.md            # This file
+├── backend/                      # Laravel API application
+│   ├── app/                      # Core application logic
+│   ├── config/                   # Application configuration files
+│   ├── database/                 # Migrations, factories, and seeders
+│   ├── routes/                   # API route definitions
+│   ├── tests/                    # Automated test suites
+│   ├── storage/                  # Runtime storage for logs and generated docs
+│   ├── .env.example              # Backend environment template
+│   ├── Dockerfile                # Backend container image definition
+│   └── Dockerfile.production     # Production backend image definition
+├── frontend/                     # Vue 3 application
+│   ├── src/                      # Vue components, views, and pages
+│   ├── public/                   # Static public assets
+│   ├── package.json              # Frontend package manifest
+│   ├── Dockerfile                # Frontend container image definition
+│   └── Dockerfile.production     # Production frontend image definition
+├── database/                     # Database-related configuration and assets
+│   ├── sql/                      # SQL scripts and stored procedures
+│   ├── pgadmin/                  # pgAdmin configuration files
+│   └── backups/                  # Database backup files
+├── compose.yaml                  # Development service orchestration
+├── compose.prod.yaml             # Production service orchestration
+└── README.md                     # Project documentation
 ```
 
 ## Quick Start
@@ -309,3 +317,4 @@ docker compose exec backend php artisan migrate
 For issues or questions, refer to the individual README files:
 - [Backend README](backend/README.md)
 - [API Endpoints](backend/ENDPOINTS.md)
+- [Backup Policy](BACKUP_POLICY.md)

--- a/backend/Dockerfile.production
+++ b/backend/Dockerfile.production
@@ -1,0 +1,35 @@
+FROM php:8.4-cli
+
+RUN apt-get update && apt-get install -y \
+    git \
+    curl \
+    unzip \
+    libonig-dev \
+    libpq-dev \
+    libsqlite3-dev \
+    libzip-dev \
+    zip \
+    && docker-php-ext-install mbstring pdo pdo_pgsql pdo_sqlite zip opcache \
+    && rm -rf /var/lib/apt/lists/* \
+    && echo "opcache.enable=1" >> /usr/local/etc/php/php.ini \
+    && echo "opcache.enable_cli=1" >> /usr/local/etc/php/php.ini \
+    && echo "opcache.memory_consumption=128" >> /usr/local/etc/php/php.ini \
+    && echo "opcache.interned_strings_buffer=8" >> /usr/local/etc/php/php.ini \
+    && echo "opcache.max_accelerated_files=8000" >> /usr/local/etc/php/php.ini \
+    && echo "opcache.validate_timestamps=1" >> /usr/local/etc/php/php.ini \
+    && echo "opcache.revalidate_freq=2" >> /usr/local/etc/php/php.ini
+
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
+WORKDIR /var/www
+
+COPY backend/ ./
+COPY database/sql/ /var/www/database_sql/
+
+RUN composer install --no-interaction --no-dev --prefer-dist --optimize-autoloader
+
+COPY backend/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["docker-entrypoint.sh"]

--- a/compose.prod.yaml
+++ b/compose.prod.yaml
@@ -1,0 +1,62 @@
+services:
+  backend:
+    hostname: laravel_backend_prod
+    container_name: laravel_backend_prod
+    build:
+      context: .
+      dockerfile: backend/Dockerfile.production
+    working_dir: /var/www
+    ports:
+      - "${BACKEND_PORT}:8000"
+    environment:
+      TZ: UTC
+      APP_ENV: production
+      APP_DEBUG: "false"
+      APP_URL: "http://localhost:${BACKEND_PORT}"
+      BACKEND_PORT: ${BACKEND_PORT}
+      POSTGRES_HOST: database
+      POSTGRES_PORT: ${POSTGRES_PORT}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    restart: unless-stopped
+    depends_on:
+      database:
+        condition: service_healthy
+
+  frontend:
+    hostname: vue_frontend_prod
+    container_name: vue_frontend_prod
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile.production
+      args:
+        VITE_API_BASE: "http://localhost:${BACKEND_PORT}/api/v1"
+    ports:
+      - "${FRONTEND_PORT}:80"
+    environment:
+      TZ: UTC
+    restart: unless-stopped
+    depends_on:
+      - backend
+
+  database:
+    image: postgres:17-alpine
+    container_name: postgres_db_prod
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+    ports:
+      - "${POSTGRES_PORT}:5432"
+    volumes:
+      - postgres_data_prod:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB} || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  postgres_data_prod:

--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -1,0 +1,21 @@
+FROM node:22-alpine AS build
+
+WORKDIR /frontend
+
+ARG VITE_API_BASE=http://localhost:8000/api/v1
+ENV VITE_API_BASE=${VITE_API_BASE}
+
+COPY package*.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build
+
+FROM nginx:1.27-alpine AS runtime
+
+COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /frontend/dist /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,0 +1,15 @@
+server {
+    listen 80;
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|svg|ico|webp)$ {
+        expires 7d;
+        add_header Cache-Control "public, max-age=604800, immutable";
+    }
+}


### PR DESCRIPTION
This PR adds a production-ready Docker setup for the full CAA stack.

It includes:
- a production frontend image served by Nginx
- a production backend image without the dev bind mount
- a combined compose.prod.yaml that runs frontend, backend, and database together
- README updates for the new production workflow

It also fixes the backend startup issue by bundling the SQL assets required by the migration step into the production image.

**Verification**
- `docker compose -f compose.prod.yaml config`
- `docker compose -f compose.prod.yaml build backend frontend`
- confirmed the backend container starts successfully and stays running